### PR TITLE
[Feature]: アプリ名の変更

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Flush</string>
+    <string name="app_name">Poitto</string>
 </resources>


### PR DESCRIPTION
## 概要
アプリ名が決まったのにもかかわらず、仮置きで使用していたFlushのままだったためPoittoに変更

## 実施Issue
#30 
