### PR TITLE
feat: TopBarの見た目変更

### DIFF
--- a/app/src/main/java/com/example/flush/ui/compose/TopBar.kt
+++ b/app/src/main/java/com/example/flush/ui/compose/TopBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,6 +19,7 @@ fun TopBar(
     @Composable()
     (RowScope.() -> Unit) = {},
     contentColor: Color = MaterialTheme.colorScheme.primary,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
 ) {
     TopAppBar(
         title = {
@@ -31,5 +33,8 @@ fun TopBar(
         modifier = modifier,
         navigationIcon = navigationIcon,
         actions = actions,
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = containerColor,
+        ),
     )
 }

--- a/app/src/main/java/com/example/flush/ui/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/search/SearchScreen.kt
@@ -1,5 +1,7 @@
 package com.example.flush.ui.feature.search
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -14,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -25,6 +28,7 @@ import com.example.flush.ui.compose.FloatingActionButton
 import com.example.flush.ui.compose.Icon
 import com.example.flush.ui.compose.Loading
 import com.example.flush.ui.compose.TopBar
+import com.example.flush.ui.feature.search.SearchScreenDimensions.UserIconBorderWidth
 import com.example.flush.ui.theme.dimensions.IconSize
 import com.example.flush.ui.theme.dimensions.Paddings
 import com.example.flush.ui.utils.showToast
@@ -102,13 +106,12 @@ private fun SearchScreen(
                 onNavigateToPost = { onEvent(SearchUiEvent.OnNavigateToPostClick) },
             )
         },
-    ) { innerPadding ->
+    ) { _ ->
         SearchScreenContent(
             uiState = uiState,
             onEvent = onEvent,
             modifier = Modifier
-                .fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding()),
+                .fillMaxSize(),
         )
     }
 
@@ -129,31 +132,79 @@ private fun SearchScreenTopBar(
         title = "サーチ",
         modifier = modifier,
         actions = {
-            when {
-                userIconUrl != null -> {
-                    AsyncImage(
-                        uri = userIconUrl,
-                        modifier = Modifier
-                            .padding(end = Paddings.Medium)
-                            .size(IconSize.Medium)
-                            .clickable { onNavigateToUserSettings() },
-                        shape = CircleShape,
-                    )
-                }
-
-                else -> {
-                    Icon(
-                        icon = Icons.Rounded.Person,
-                        modifier = Modifier
-                            .size(IconSize.Medium)
-                            .padding(end = Paddings.Medium)
-                            .clip(CircleShape)
-                            .clickable { onNavigateToUserSettings() },
-                        size = IconSize.Medium,
-                    )
-                }
-            }
+            TopBarActionButton(
+                userIconUrl = userIconUrl,
+                onNavigateToUserSettings = onNavigateToUserSettings,
+            )
         },
+        contentColor = Color.White,
+        containerColor = Color.Transparent,
+    )
+}
+
+@Composable
+private fun TopBarActionButton(
+    userIconUrl: String?,
+    onNavigateToUserSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when {
+        userIconUrl != null -> {
+            UserIcon(
+                userIconUrl = userIconUrl,
+                modifier = modifier
+                    .clickable { onNavigateToUserSettings() },
+            )
+        }
+
+        else -> {
+            DefaultUseIcon(
+                modifier = modifier
+                    .clickable { onNavigateToUserSettings() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun UserIcon(
+    userIconUrl: String,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        uri = userIconUrl,
+        modifier = modifier
+            .padding(end = Paddings.Medium)
+            .size(IconSize.Medium)
+            .border(
+                border = BorderStroke(
+                    width = UserIconBorderWidth,
+                    color = Color.White,
+                ),
+                shape = CircleShape,
+            ),
+        shape = CircleShape,
+    )
+}
+
+@Composable
+private fun DefaultUseIcon(
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        icon = Icons.Rounded.Person,
+        modifier = modifier
+            .size(IconSize.Medium)
+            .padding(end = Paddings.Medium)
+            .border(
+                border = BorderStroke(
+                    width = UserIconBorderWidth,
+                    color = Color.White,
+                ),
+                shape = CircleShape,
+            )
+            .clip(CircleShape),
+        size = IconSize.Medium,
     )
 }
 

--- a/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenDimensions.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenDimensions.kt
@@ -5,4 +5,6 @@ import androidx.compose.ui.unit.dp
 object SearchScreenDimensions {
     val PreviewImageHeight = 300.dp
     val ParameterThickness = 5.dp
+
+    val UserIconBorderWidth = 2.dp
 }


### PR DESCRIPTION
## 概要
TopBarの見た目がダサくよりよいデザインにするために変更を行った。具体的には、TopBarの背景色削除で宇宙空間を全体に広げるように変更した。それだけでは、ユーザアイコンが見えにくいため、ユーザアイコンにBorderをつけた。

## 実施Issue
#33 

<!-- UIに変更があった際に使用 -->
## UI変更
| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/d0f206f3-5873-48d8-bd33-1bd6e81daab5" width="300" /> | <img src="https://github.com/user-attachments/assets/34987847-0103-4b8d-a9b9-6545be8f7afe" width="300" /> |
