### PR TITLE
[Bug]: SearchScreenの3Dモデルが等間隔に並びすぎている

### DIFF
--- a/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenContent.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenContent.kt
@@ -25,6 +25,8 @@ import io.github.sceneview.rememberOnGestureListener
 import kotlin.random.Random
 
 private const val SpeedFactor = 0.1f
+private const val MinPositionValue = -2f
+private const val MaxPositionValue = 2f
 
 @Suppress("LongMethod", "MultipleEmitters")
 @Composable
@@ -102,9 +104,9 @@ fun SearchScreenContent(
 
                     // 範囲チェック (例えば -1.0f～1.0f の範囲内に制約)
                     node.position = Position(
-                        x = newPosition.x.coerceIn(-2.0f, 2.0f),
-                        y = newPosition.y.coerceIn(-2.0f, 2.0f),
-                        z = newPosition.z.coerceIn(-2.0f, 2.0f),
+                        x = newPosition.x.coerceIn(MinPositionValue, MaxPositionValue),
+                        y = newPosition.y.coerceIn(MinPositionValue, MaxPositionValue),
+                        z = newPosition.z.coerceIn(MinPositionValue, MaxPositionValue),
                     )
 
                     // 回転速度を適用
@@ -112,10 +114,10 @@ fun SearchScreenContent(
                     node.rotation.y += direction.rotationSpeed * SpeedFactor
 
                     // 範囲外に出たら方向を反転
-                    if (newPosition.x <= -2.0f || newPosition.x >= 2.0f) {
+                    if (newPosition.x <= MinPositionValue || newPosition.x >= MaxPositionValue) {
                         modelNodes[index] = node to direction.copy(x = -direction.x)
                     }
-                    if (newPosition.y <= -2.0f || newPosition.y >= 2.0f) {
+                    if (newPosition.y <= MinPositionValue || newPosition.y >= MaxPositionValue) {
                         modelNodes[index] = node to direction.copy(y = -direction.y)
                     }
                 }
@@ -142,9 +144,6 @@ data class Direction(
         return Position(x, y, z)
     }
 }
-
-private const val MinPositionValue = -2f
-private const val MaxPositionValue = 2f
 
 private fun randomPosition() = Position(
     x = Random.nextFloatInRange(MinPositionValue, MaxPositionValue),

--- a/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenContent.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/search/SearchScreenContent.kt
@@ -102,9 +102,9 @@ fun SearchScreenContent(
 
                     // 範囲チェック (例えば -1.0f～1.0f の範囲内に制約)
                     node.position = Position(
-                        x = newPosition.x.coerceIn(-1.0f, 1.0f),
-                        y = newPosition.y.coerceIn(-1.0f, 1.0f),
-                        z = newPosition.z.coerceIn(-1.0f, 1.0f),
+                        x = newPosition.x.coerceIn(-2.0f, 2.0f),
+                        y = newPosition.y.coerceIn(-2.0f, 2.0f),
+                        z = newPosition.z.coerceIn(-2.0f, 2.0f),
                     )
 
                     // 回転速度を適用
@@ -112,10 +112,10 @@ fun SearchScreenContent(
                     node.rotation.y += direction.rotationSpeed * SpeedFactor
 
                     // 範囲外に出たら方向を反転
-                    if (newPosition.x <= -1.0f || newPosition.x >= 1.0f) {
+                    if (newPosition.x <= -2.0f || newPosition.x >= 2.0f) {
                         modelNodes[index] = node to direction.copy(x = -direction.x)
                     }
-                    if (newPosition.y <= -1.0f || newPosition.y >= 1.0f) {
+                    if (newPosition.y <= -2.0f || newPosition.y >= 2.0f) {
                         modelNodes[index] = node to direction.copy(y = -direction.y)
                     }
                 }
@@ -143,14 +143,18 @@ data class Direction(
     }
 }
 
-private const val MinPositionValue = -2
-private const val MaxPositionValue = 2
+private const val MinPositionValue = -2f
+private const val MaxPositionValue = 2f
 
 private fun randomPosition() = Position(
-    x = Random.nextInt(MinPositionValue, MaxPositionValue).toFloat(),
-    y = Random.nextInt(MinPositionValue, MaxPositionValue).toFloat(),
-    z = Random.nextInt(MinPositionValue, MaxPositionValue).toFloat(),
+    x = Random.nextFloatInRange(MinPositionValue, MaxPositionValue),
+    y = Random.nextFloatInRange(MinPositionValue, MaxPositionValue),
+    z = Random.nextFloatInRange(MinPositionValue, MaxPositionValue),
 )
+
+private fun Random.nextFloatInRange(min: Float, max: Float): Float {
+    return min + this.nextFloat() * (max - min)
+}
 
 private const val MinRotationValue = 0
 private const val MaxRotationValue = 360


### PR DESCRIPTION
## 概要
3Dモデルがきれいに並びすぎていて、漂流しているような感じにならなかったため、ランダムな位置に配置されるように変更

## 実施Issue
#35 

<!-- 以下は、条件に当てはまった際に使用 -->
<!-- バグの修正の際にのみ使用 -->
## 原因と対処
幅が狭い中で、nextIntを使用していたため値がバラけなかった。そのため、Floatのランダムな値を生成する関数を実装し表示されるようにした。また、値の範囲を広げよりばらばらに配置されるようにした。

<!-- UIに変更があった際に使用 -->
## UI変更
| After |
|-------|
| <img src="https://github.com/user-attachments/assets/55ff1791-d86a-4d4f-a01f-ae5d21d496d4" width="300" /> |