### PR TITLE
[Feature]: SignInScreenの実装

### DIFF
--- a/app/src/main/java/com/example/flush/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/flush/data/repository/AuthRepositoryImpl.kt
@@ -46,6 +46,16 @@ class AuthRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun signInWithEmail(email: String, password: String): Result<AuthResult> =
+        withContext(ioDispatcher) {
+            try {
+                val result = auth.signInWithEmailAndPassword(email, password).await()
+                Result.success(result)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
     override suspend fun requestGoogleOneTapAuth(): IntentSenderRequest =
         withContext(ioDispatcher) {
             try {

--- a/app/src/main/java/com/example/flush/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/flush/domain/repository/AuthRepository.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseUser
 interface AuthRepository {
     fun getCurrentUser(): FirebaseUser?
     suspend fun signUpWithEmail(email: String, password: String): Result<FirebaseUser>
+    suspend fun signInWithEmail(email: String, password: String): Result<AuthResult>
     suspend fun requestGoogleOneTapAuth(): IntentSenderRequest
     suspend fun signInWithGoogle(resultData: Intent): Result<AuthResult>
     suspend fun signOut(): Result<Unit>

--- a/app/src/main/java/com/example/flush/domain/use_case/SignInWithEmailUseCase.kt
+++ b/app/src/main/java/com/example/flush/domain/use_case/SignInWithEmailUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.flush.domain.use_case
+
+import com.example.flush.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class SignInWithEmailUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(email: String, password: String) = authRepository.signInWithEmail(email, password)
+}

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreen.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreen.kt
@@ -1,30 +1,126 @@
 package com.example.flush.ui.feature.sign_in
 
-import androidx.compose.foundation.layout.Column
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBackIosNew
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import com.example.flush.ui.compose.BodyMediumText
-import com.example.flush.ui.compose.CenteredContainer
-import com.example.flush.ui.compose.FilledButton
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import com.example.flush.ui.compose.FadeInAnimateVisibility
+import com.example.flush.ui.compose.IconButton
+import com.example.flush.ui.compose.Loading
+import com.example.flush.ui.compose.TopBar
+import com.example.flush.ui.utils.showToast
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @Suppress("ModifierMissing")
 @Composable
 fun SignInScreen(
-    navigateToSignUp: () -> Unit,
+    navigateToAuthSelection: () -> Unit,
     navigateToSearch: () -> Unit,
+    viewModel: SignInViewModel = hiltViewModel(),
 ) {
-    CenteredContainer {
-        Column {
-            BodyMediumText(
-                text = "SignInScreen",
-            )
-            FilledButton(
-                text = "navigateToSignUp",
-                onClick = navigateToSignUp,
-            )
-            FilledButton(
-                text = "navigateToSearch",
-                onClick = navigateToSearch,
-            )
-        }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val context = LocalContext.current
+
+    val latestNavigateToAuthSelection by rememberUpdatedState(navigateToAuthSelection)
+    val latestNavigateToSearch by rememberUpdatedState(navigateToSearch)
+
+    val googleSignInLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+        onResult = { result ->
+            viewModel.handleSignInResult(result.data)
+        },
+    )
+
+    LaunchedEffect(lifecycleOwner, viewModel) {
+        viewModel.uiEvent.flowWithLifecycle(lifecycleOwner.lifecycle).onEach { event ->
+            when (event) {
+                is SignInUiEvent.OnNavigateToAuthSelectionClick -> latestNavigateToAuthSelection()
+                is SignInUiEvent.OnEmailInputChange -> viewModel.updateEmail(event.email)
+                is SignInUiEvent.OnPasswordInputChange -> viewModel.updatePassword(event.password)
+                is SignInUiEvent.OnSubmitClick -> viewModel.submitRegister()
+                is SignInUiEvent.OnGoogleSignUpClick -> viewModel.startGoogleSignIn(googleSignInLauncher)
+            }
+        }.launchIn(this)
     }
+
+    LaunchedEffect(lifecycleOwner, viewModel) {
+        viewModel.uiEffect.flowWithLifecycle(lifecycleOwner.lifecycle).onEach { effect ->
+            when (effect) {
+                is SignInUiEffect.NavigateToSearch -> latestNavigateToSearch()
+                is SignInUiEffect.ShowToast -> showToast(context, effect.message)
+            }
+        }.launchIn(this)
+    }
+
+    SignInScreen(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@Composable
+private fun SignInScreen(
+    uiState: SignInUiState,
+    onEvent: (SignInUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            SignInScreenTopBar(
+                onNavigateToAuthSelection = { onEvent(SignInUiEvent.OnNavigateToAuthSelectionClick) },
+            )
+        },
+    ) { innerPadding ->
+        SignInScreenContent(
+            uiState = uiState,
+            onEvent = onEvent,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        )
+    }
+
+    FadeInAnimateVisibility(
+        visible = uiState.isLoading,
+    ) {
+        Loading()
+    }
+}
+
+@Composable
+private fun SignInScreenTopBar(
+    onNavigateToAuthSelection: () -> Unit,
+) {
+    TopBar(
+        title = null,
+        modifier = Modifier.fillMaxWidth(),
+        navigationIcon = {
+            IconButton(
+                icon = Icons.Outlined.ArrowBackIosNew,
+                onClick = onNavigateToAuthSelection,
+                contentColor = MaterialTheme.colorScheme.primary,
+            )
+        },
+    )
 }

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreenContent.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreenContent.kt
@@ -1,0 +1,159 @@
+package com.example.flush.ui.feature.sign_in
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.example.flush.R
+import com.example.flush.ui.compose.BodyMediumText
+import com.example.flush.ui.compose.EmailTextField
+import com.example.flush.ui.compose.FilledButton
+import com.example.flush.ui.compose.Image
+import com.example.flush.ui.compose.PasswordTextField
+import com.example.flush.ui.compose.TitleLargeText
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.BorderStrokeWidth
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.EmailTextFieldHeight
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.GoogleSignUpButtonHeight
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.HorizontalDividerWidth
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.MinPasswordLength
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.PasswordTextFieldHeight
+import com.example.flush.ui.feature.sign_in.SignInScreenDimensions.SubmitButtonHeight
+import com.example.flush.ui.theme.dimensions.Paddings
+
+@Composable
+fun SignInScreenContent(
+    uiState: SignInUiState,
+    onEvent: (SignInUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = Paddings.Large),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Paddings.Large),
+    ) {
+        SignUpHeader()
+        EmailSignUpFields(
+            uiState = uiState,
+            onEvent = onEvent,
+        )
+        HorizontalDivider(
+            modifier = Modifier
+                .width(HorizontalDividerWidth)
+                .padding(vertical = Paddings.Large),
+        )
+        GoogleSignInButton(
+            onClick = { onEvent(SignInUiEvent.OnGoogleSignUpClick) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SignUpHeader(
+    modifier: Modifier = Modifier,
+) {
+    TitleLargeText(
+        text = "サインイン",
+        modifier = modifier
+            .padding(Paddings.Medium),
+        color = MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun EmailSignUpFields(
+    uiState: SignInUiState,
+    onEvent: (SignInUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Paddings.ExtraLarge),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Paddings.Large),
+        ) {
+            EmailTextField(
+                email = uiState.email,
+                onEmailChange = { onEvent(SignInUiEvent.OnEmailInputChange(it)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(EmailTextFieldHeight),
+            )
+            PasswordTextField(
+                password = uiState.password,
+                onPasswordChange = { onEvent(SignInUiEvent.OnPasswordInputChange(it)) },
+                enable = uiState.password.length >= MinPasswordLength,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(PasswordTextFieldHeight),
+            )
+        }
+        SubmitButton(
+            onSubmit = { onEvent(SignInUiEvent.OnSubmitClick) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = uiState.email.isNotEmpty() && uiState.password.length >= MinPasswordLength,
+        )
+    }
+}
+
+@Composable
+private fun SubmitButton(
+    onSubmit: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    FilledButton(
+        text = "サインイン",
+        onClick = onSubmit,
+        modifier = modifier
+            .height(SubmitButtonHeight),
+        enabled = enabled,
+    )
+}
+
+@Composable
+private fun GoogleSignInButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.material3.OutlinedButton(
+        onClick = onClick,
+        modifier = modifier
+            .height(GoogleSignUpButtonHeight),
+        shape = MaterialTheme.shapes.small,
+        contentPadding = PaddingValues(
+            horizontal = Paddings.Medium,
+            vertical = Paddings.Small,
+        ),
+        border = BorderStroke(width = BorderStrokeWidth, MaterialTheme.colorScheme.onSurface),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                resId = R.drawable.ic_google,
+                modifier = Modifier.align(Alignment.CenterStart),
+            )
+            BodyMediumText(
+                text = "Googleでサインイン",
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreenDimensions.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInScreenDimensions.kt
@@ -1,0 +1,14 @@
+package com.example.flush.ui.feature.sign_in
+
+import androidx.compose.ui.unit.dp
+
+data object SignInScreenDimensions {
+    val EmailTextFieldHeight = 56.dp
+    val PasswordTextFieldHeight = 56.dp
+    val SubmitButtonHeight = 56.dp
+    val GoogleSignUpButtonHeight = 56.dp
+    val HorizontalDividerWidth = 200.dp
+    val BorderStrokeWidth = 2.dp
+
+    const val MinPasswordLength = 6
+}

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiEffect.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiEffect.kt
@@ -1,0 +1,8 @@
+package com.example.flush.ui.feature.sign_in
+
+import com.example.flush.ui.base.UiEffect
+
+interface SignInUiEffect : UiEffect {
+    data class ShowToast(val message: String) : SignInUiEffect
+    data object NavigateToSearch : SignInUiEffect
+}

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiEvent.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiEvent.kt
@@ -1,0 +1,11 @@
+package com.example.flush.ui.feature.sign_in
+
+import com.example.flush.ui.base.UiEvent
+
+sealed interface SignInUiEvent : UiEvent {
+    data object OnNavigateToAuthSelectionClick : SignInUiEvent
+    data class OnEmailInputChange(val email: String) : SignInUiEvent
+    data class OnPasswordInputChange(val password: String) : SignInUiEvent
+    data object OnSubmitClick : SignInUiEvent
+    data object OnGoogleSignUpClick : SignInUiEvent
+}

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiState.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInUiState.kt
@@ -1,0 +1,9 @@
+package com.example.flush.ui.feature.sign_in
+
+import com.example.flush.ui.base.UiState
+
+data class SignInUiState(
+    val email: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false,
+) : UiState

--- a/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_in/SignInViewModel.kt
@@ -1,0 +1,68 @@
+package com.example.flush.ui.feature.sign_in
+
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.lifecycle.viewModelScope
+import com.example.flush.domain.use_case.RequestGoogleOneTapAuthUseCase
+import com.example.flush.domain.use_case.SignInWithEmailUseCase
+import com.example.flush.domain.use_case.SignInWithGoogleUseCase
+import com.example.flush.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SignInViewModel @Inject constructor(
+    private val signInWithEmailUseCase: SignInWithEmailUseCase,
+    private val requestGoogleOneTapAuthUseCase: RequestGoogleOneTapAuthUseCase,
+    private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
+) : BaseViewModel<SignInUiState, SignInUiEvent, SignInUiEffect>(SignInUiState()) {
+
+    fun updateEmail(email: String) {
+        updateUiState { it.copy(email = email) }
+    }
+
+    fun updatePassword(password: String) {
+        updateUiState { it.copy(password = password) }
+    }
+
+    fun submitRegister() {
+        viewModelScope.launch {
+            updateUiState { it.copy(isLoading = true) }
+            val email = uiState.value.email
+            val password = uiState.value.password
+            val result = signInWithEmailUseCase(email, password)
+            updateUiState { it.copy(isLoading = false) }
+            if (result.isSuccess) {
+                sendEffect(SignInUiEffect.NavigateToSearch)
+            } else {
+                sendEffect(SignInUiEffect.ShowToast("Failed to register"))
+            }
+        }
+    }
+
+    fun startGoogleSignIn(launcher: ActivityResultLauncher<IntentSenderRequest>) {
+        viewModelScope.launch {
+            updateUiState { it.copy(isLoading = true) }
+            val intentSenderRequest = requestGoogleOneTapAuthUseCase()
+            launcher.launch(intentSenderRequest)
+        }
+    }
+
+    fun handleSignInResult(launcherResult: Intent?) {
+        viewModelScope.launch {
+            if (launcherResult != null) {
+                val result = signInWithGoogleUseCase(launcherResult)
+                updateUiState { it.copy(isLoading = false) }
+                if (result.isSuccess) {
+                    sendEffect(SignInUiEffect.NavigateToSearch)
+                } else {
+                    sendEffect(SignInUiEffect.ShowToast("Failed to sign in"))
+                }
+            } else {
+                sendEffect(SignInUiEffect.ShowToast("Failed to sign in"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/flush/ui/navigation/FlushNavHost.kt
+++ b/app/src/main/java/com/example/flush/ui/navigation/FlushNavHost.kt
@@ -40,7 +40,7 @@ fun FlushNavHost(
 
         composable<Screen.SignIn> {
             SignInScreen(
-                navigateToSignUp = { navController.navigateTo(Screen.SignUp) },
+                navigateToAuthSelection = { navController.navigateTo(Screen.AuthSelection) },
                 navigateToSearch = { navController.navigateTo(Screen.Search) },
             )
         }


### PR DESCRIPTION
## 概要
SignIn画面の実装を行った。これまでは、新規登録は出来るが既存のアカウントにログインする処理がなかった。そのため、今回新たに既存のアカウントにログインする処理を追加した。それを行うための画面も作成した。

## 実施Issue
#10 

<!-- UIに変更があった際に使用 -->
## UI変更
| After |
|-------|
| <img src="https://github.com/user-attachments/assets/2ca5bf88-ab76-4905-b874-20b8d1ad695a" width="300" /> |
